### PR TITLE
Tools proj card

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -28,12 +28,12 @@
       "dateDue": "05/01/2021"
     },
     {
-      "name": "2342341",
-      "categoryId": 5,
-      "description": "12341234",
       "userId": 1,
-      "dateCreated": "3/22/2021, 7:08:39 PM",
-      "dateDue": "",
+      "name": "Nicole Tatum",
+      "categoryId": "3",
+      "description": "sadcfsa",
+      "dateCreated": "3/24/2021, 5:57:07 PM",
+      "dateDue": "2021-03-11T17:57",
       "id": 4
     }
   ],
@@ -211,6 +211,11 @@
       "id": 4,
       "materialId": 8,
       "projectId": 1
+    },
+    {
+      "id": 5,
+      "materialId": 1,
+      "projectId": 2
     }
   ],
   "projectsTools": [

--- a/api/database.json
+++ b/api/database.json
@@ -35,6 +35,15 @@
       "dateCreated": "3/24/2021, 5:57:07 PM",
       "dateDue": "2021-03-11T17:57",
       "id": 4
+    },
+    {
+      "userId": 1,
+      "name": "Nicole Tatum",
+      "categoryId": "6",
+      "description": "asdf",
+      "dateCreated": "3/25/2021, 12:12:15 AM",
+      "dateDue": "",
+      "id": 5
     }
   ],
   "users": [
@@ -137,6 +146,11 @@
       "id": 10,
       "name": "screw",
       "userId": 1
+    },
+    {
+      "name": "glitter",
+      "userId": 1,
+      "id": 11
     }
   ],
   "tools": [
@@ -189,6 +203,16 @@
       "id": 10,
       "name": "sandpaper",
       "userId": 1
+    },
+    {
+      "name": "cheese",
+      "userId": 1,
+      "id": 15
+    },
+    {
+      "name": "rubber duck",
+      "userId": 1,
+      "id": 16
     }
   ],
   "projectsMaterials": [
@@ -216,6 +240,26 @@
       "id": 5,
       "materialId": 1,
       "projectId": 2
+    },
+    {
+      "projectId": 0,
+      "materialId": 0,
+      "id": 6
+    },
+    {
+      "projectId": 0,
+      "materialId": 0,
+      "id": 7
+    },
+    {
+      "projectId": 0,
+      "materialId": 0,
+      "id": 8
+    },
+    {
+      "projectId": 0,
+      "materialId": 0,
+      "id": 9
     }
   ],
   "projectsTools": [

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -8,6 +8,7 @@ import { ProjectEdit } from "./ProjectsBoard/EditProject"
 import { ToolProvider } from "./Tools/ToolProvider"
 import { MaterialProvider } from "./Materials/MaterialProvider"
 import { ProjectMaterialProvider } from "./Materials/MaterialProjectProvider"
+import { ProjectToolProvider } from "./Tools/ToolProjectProvider"
 export const ApplicationViews = () => {
     return (
         <>
@@ -19,15 +20,17 @@ export const ApplicationViews = () => {
                 <ToolProvider>
                     <MaterialProvider>
                         <ProjectMaterialProvider>
-                        <Route exact path="/projects">
-                            <ProjectBoard />
-                        </Route>
-                        <Route path="/addProject">
-                            <CreateProject />
-                        </Route>
-                        <Route path="/projects/edit/:projectId(\d+)">
-                            <ProjectEdit />
-                        </Route>
+                            <ProjectToolProvider>
+                                <Route exact path="/projects">
+                                    <ProjectBoard />
+                                </Route>
+                                <Route path="/addProject">
+                                    <CreateProject />
+                                </Route>
+                                <Route path="/projects/edit/:projectId(\d+)">
+                                    <ProjectEdit />
+                                </Route>
+                            </ProjectToolProvider>
                         </ProjectMaterialProvider>
                     </MaterialProvider>
                 </ToolProvider>

--- a/src/components/Materials/AddMaterial.js
+++ b/src/components/Materials/AddMaterial.js
@@ -1,0 +1,2 @@
+// import React, { useContext, useEffect, useState } from "react"
+// import { useHistory } from 'react-router-dom';

--- a/src/components/Materials/AddMaterial.js
+++ b/src/components/Materials/AddMaterial.js
@@ -1,2 +1,0 @@
-// import React, { useContext, useEffect, useState } from "react"
-// import { useHistory } from 'react-router-dom';

--- a/src/components/Materials/MaterialProjectProvider.js
+++ b/src/components/Materials/MaterialProjectProvider.js
@@ -1,6 +1,6 @@
 import { useState, createContext } from "react"
 
-//context allows a way to pass data through components tree w/o having to pass props DOWN manually at every level
+//context provides a way to pass data through components tree w/o having to pass props DOWN manually at every level
 export const ProjectMaterialContext = createContext()
 
 export const ProjectMaterialProvider = (props) => {
@@ -9,7 +9,7 @@ export const ProjectMaterialProvider = (props) => {
     const [projectsMaterials, setProjectsMaterials] = useState([])
 
     const getProjectsMaterials = () => {
-        return fetch("http://localhost:8088/projectsMaterials?_expand=material")
+        return fetch("http://localhost:8088/projectsMaterials?_expand=material&_expand=project")
         .then(response => response.json())
         .then(setProjectsMaterials)
     }
@@ -21,21 +21,22 @@ export const ProjectMaterialProvider = (props) => {
 
     //addprojectmaterial. to add all of the materials to project materials 
 
-    // const addprojectMaterial = projectMaterialObj => {
-    //     return fetch("http://localhost:8088/projectsMaterials",{
-    //     method: "POST",
-    //     headers: {
-    //         "Content-Type": "application/json"
-    //     },
-    //     body: JSON.stringify(projectMaterialObj)
-    //     })
-    //         .then(getProjectsMaterials)
-    // }
+    //wil check for material id and project id
+    const addProjectMaterial = projectMaterialObj => {
+        return fetch("http://localhost:8088/projectsMaterials",{
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(projectMaterialObj)
+        })
+            .then(getProjectsMaterials)
+    }
 
     //allows access to children of "props"??
     return (
         <ProjectMaterialContext.Provider value={{
-            projectsMaterials, getProjectsMaterials, getProjectMaterialById
+            projectsMaterials, getProjectsMaterials, getProjectMaterialById, addProjectMaterial
         }}>
             {props.children}
         </ProjectMaterialContext.Provider>

--- a/src/components/ProjectsBoard/AddProject.js
+++ b/src/components/ProjectsBoard/AddProject.js
@@ -7,12 +7,14 @@ import { MaterialContext } from "../Materials/MaterialProvider"
 import { Form, FormLabel, Button, Jumbotron, Modal } from "react-bootstrap";
 import { Multiselect } from 'multiselect-react-dropdown'
 import "./ProjectBoard.css"
+import { ProjectMaterialContext } from "../Materials/MaterialProjectProvider";
 
 export const CreateProject = () => {
     //allows us to access components through tree 
     const { addProject, getCategories, categories } = useContext(ProjectContext)
     const { getTools, tools } = useContext(ToolContext)
     const { getMaterials, materials } = useContext(MaterialContext)
+    const { addProjectMaterial } = useContext(ProjectMaterialContext)
 
     let currentUser = parseInt(sessionStorage.getItem(userStorageKey))
     const timestamp = new Date().toLocaleString()
@@ -21,14 +23,23 @@ export const CreateProject = () => {
     const [project, setProject] = useState({
         "userId": currentUser,
         "name": "",
-        "categoryId": "",
+        "categoryId": 0,
         "description": "",
         "dateCreated": timestamp,
         "dateDue": ""
     })
+    //store projmat data
+    const [projectMaterial, setProjectMaterial] = useState({
+        "projectId": 0,
+        "materialId": 0
+    })
     //gives objecct w/methods on it. will routre back to url
     const history = useHistory();
 
+//ASK FOR CLARIFICATION
+    //new project is created. ...is used to grab whole object and not have to go through and add each ?child? ?value?
+    //then value is added to new project if ?id is added?
+    //then newProject is added using setProject 'form'
     const handleControlledInputChange = (event) => {
         const newProject = { ...project }
         let selectedVal = event.target.value
@@ -39,11 +50,36 @@ export const CreateProject = () => {
         setProject(newProject)
     }
 
+//ASK WHY PREVENT DEFAULT
+    //project object is pushed to projects array using addProject function
     const handleClickSaveProject = (event) => {
         event.preventDefault()
         addProject(project)
             .then(() => history.push("/projects"))
     }
+
+    const handleControlledInputChangeProjectMaterial = (event) => {
+        const newProjectMaterial = { ...projectMaterial }
+        let selectedVal = event.target.value
+        if (event.target.id.includes("id")) {
+            selectedVal = parseInt(selectedVal)
+        }
+        newProjectMaterial[event.target.id] = selectedVal
+        setProjectMaterial(newProjectMaterial)
+    }
+
+
+    // const handleMultiSelect = (selectedList,selectedItem ) => {
+    //     const newSelectedEmployees = selectedEmployees.slice()
+    //     newSelectedEmployees.push(selectedItem)
+    //     setSelectedEmployees(newSelectedEmployees)
+    // }
+
+    const handleClickSaveProjectMaterial = (event) => {
+        event.preventDefault()
+        addProjectMaterial(projectMaterial)
+    }
+
     const [showTool, setShowTool] = useState(false);
     const handleCloseTool = () => setShowTool(false);
     const handleShowTool = () => setShowTool(true);
@@ -112,11 +148,11 @@ export const CreateProject = () => {
                     </Modal>
                 </div>
                 <Form.Group>
-                    <Form.Label id="project.materials"> Materials needed: </Form.Label>
+                    <Form.Label id="materials"> Materials needed: </Form.Label>
                     <Multiselect
                         options={materials} // Options to display in the dropdown
                         selectedValues={materials.selectedValue} // Preselected value to persist in dropdown
-                        onSelect={materials.onSelect} // Function will trigger on select event
+                        onSelect={handleControlledInputChangeProjectMaterial} // Function will trigger on select event
                         onRemove={materials.onRemove} // Function will trigger on remove event
                         displayValue="name" // Property name to display in the dropdown options
                     />
@@ -144,9 +180,9 @@ export const CreateProject = () => {
                 </div>
                 <Form.Group>
                     <Form.Label id="project.dateDue"> Date Due: </Form.Label>
-                    <Form.Control type="datetime-local" />
+                    <Form.Control type="datetime-local" id="dateDue" onChange={handleControlledInputChange}/>
                 </Form.Group>
-                <Button onClick={handleClickSaveProject}> Save Project </Button>
+                <Button onClick={handleClickSaveProject, handleClickSaveProjectMaterial}> Save Project </Button>
             </Form>
         </>
     )

--- a/src/components/ProjectsBoard/AddProject.js
+++ b/src/components/ProjectsBoard/AddProject.js
@@ -7,39 +7,38 @@ import { MaterialContext } from "../Materials/MaterialProvider"
 import { Form, FormLabel, Button, Jumbotron, Modal } from "react-bootstrap";
 import { Multiselect } from 'multiselect-react-dropdown'
 import "./ProjectBoard.css"
-import { ProjectMaterialContext } from "../Materials/MaterialProjectProvider";
 
 export const CreateProject = () => {
     //allows us to access components through tree 
     const { addProject, getCategories, categories } = useContext(ProjectContext)
-    const { getTools, tools } = useContext(ToolContext)
-    const { getMaterials, materials } = useContext(MaterialContext)
-    const { addProjectMaterial } = useContext(ProjectMaterialContext)
+    const { getTools, tools, addTool } = useContext(ToolContext)
+    const { getMaterials, materials, addMaterial } = useContext(MaterialContext)
 
     let currentUser = parseInt(sessionStorage.getItem(userStorageKey))
     const timestamp = new Date().toLocaleString()
+    const history = useHistory();
 
     //storing data about project
     const [project, setProject] = useState({
         "userId": currentUser,
         "name": "",
-        "categoryId": 0,
+        "categoryId": "",
         "description": "",
         "dateCreated": timestamp,
         "dateDue": ""
     })
-    //store projmat data
-    const [projectMaterial, setProjectMaterial] = useState({
-        "projectId": 0,
-        "materialId": 0
-    })
-    //gives objecct w/methods on it. will routre back to url
-    const history = useHistory();
 
-//ASK FOR CLARIFICATION
-    //new project is created. ...is used to grab whole object and not have to go through and add each ?child? ?value?
-    //then value is added to new project if ?id is added?
-    //then newProject is added using setProject 'form'
+    const [tool, setTool] = useState({
+        "name": "",
+        "userId": currentUser
+    })
+
+    const [material, setMaterial] = useState({
+        "name": "",
+        "userId": currentUser
+    })
+
+    //gives objecct w/methods on it. will routre back to url
     const handleControlledInputChange = (event) => {
         const newProject = { ...project }
         let selectedVal = event.target.value
@@ -50,34 +49,36 @@ export const CreateProject = () => {
         setProject(newProject)
     }
 
-//ASK WHY PREVENT DEFAULT
-    //project object is pushed to projects array using addProject function
+    const handleControlledInputTool = (event) => {
+        const newTool = { ...tool }
+        let selectedVal = event.target.value
+        newTool[event.target.id] = selectedVal
+        setTool(newTool)
+    }
+
+    const handleControlledInputMaterial = (event) => {
+        const newMaterial = { ...material }
+        let selectedVal = event.target.value
+        newMaterial[event.target.id] = selectedVal
+        setMaterial(newMaterial)
+    }
+
     const handleClickSaveProject = (event) => {
         event.preventDefault()
         addProject(project)
             .then(() => history.push("/projects"))
     }
 
-    const handleControlledInputChangeProjectMaterial = (event) => {
-        const newProjectMaterial = { ...projectMaterial }
-        let selectedVal = event.target.value
-        if (event.target.id.includes("id")) {
-            selectedVal = parseInt(selectedVal)
-        }
-        newProjectMaterial[event.target.id] = selectedVal
-        setProjectMaterial(newProjectMaterial)
+    const handleClickSaveTool = (event) => {
+        event.preventDefault()
+        addTool(tool)
+        setShowTool(false);
     }
 
-
-    // const handleMultiSelect = (selectedList,selectedItem ) => {
-    //     const newSelectedEmployees = selectedEmployees.slice()
-    //     newSelectedEmployees.push(selectedItem)
-    //     setSelectedEmployees(newSelectedEmployees)
-    // }
-
-    const handleClickSaveProjectMaterial = (event) => {
+    const handleClickSaveMaterial = (event) => {
         event.preventDefault()
-        addProjectMaterial(projectMaterial)
+        addMaterial(material)
+        setShowMaterial(false)
     }
 
     const [showTool, setShowTool] = useState(false);
@@ -136,23 +137,23 @@ export const CreateProject = () => {
                         </Modal.Header>
                         <Modal.Body>
                             <Form>
-                                <Form.Control>
+                                <Form.Control type="text" id="name" onChange={handleControlledInputTool}>
                                 </Form.Control>
                             </Form>
                         </Modal.Body>
                         <Modal.Footer>
-                            <Button variant="primary" onClick={handleCloseTool}>
+                            <Button variant="primary" onClick={handleClickSaveTool}>
                                 Save
                             </Button>
                         </Modal.Footer>
                     </Modal>
                 </div>
                 <Form.Group>
-                    <Form.Label id="materials"> Materials needed: </Form.Label>
+                    <Form.Label id="project.materials"> Materials needed: </Form.Label>
                     <Multiselect
                         options={materials} // Options to display in the dropdown
                         selectedValues={materials.selectedValue} // Preselected value to persist in dropdown
-                        onSelect={handleControlledInputChangeProjectMaterial} // Function will trigger on select event
+                        onSelect={materials.onSelect} // Function will trigger on select event
                         onRemove={materials.onRemove} // Function will trigger on remove event
                         displayValue="name" // Property name to display in the dropdown options
                     />
@@ -167,12 +168,12 @@ export const CreateProject = () => {
                         </Modal.Header>
                         <Modal.Body>
                             <Form>
-                                <Form.Control>
+                                <Form.Control type="text" id="name" onChange={handleControlledInputMaterial}>
                                 </Form.Control>
                             </Form>
                         </Modal.Body>
                         <Modal.Footer>
-                            <Button variant="primary" onClick={handleCloseMaterial}>
+                            <Button variant="primary" onClick={handleClickSaveMaterial}>
                                 Save
                             </Button>
                         </Modal.Footer>
@@ -180,9 +181,9 @@ export const CreateProject = () => {
                 </div>
                 <Form.Group>
                     <Form.Label id="project.dateDue"> Date Due: </Form.Label>
-                    <Form.Control type="datetime-local" id="dateDue" onChange={handleControlledInputChange}/>
+                    <Form.Control type="datetime-local" />
                 </Form.Group>
-                <Button onClick={handleClickSaveProject, handleClickSaveProjectMaterial}> Save Project </Button>
+                <Button onClick={handleClickSaveProject}> Save Project </Button>
             </Form>
         </>
     )

--- a/src/components/ProjectsBoard/EditProject.js
+++ b/src/components/ProjectsBoard/EditProject.js
@@ -6,8 +6,7 @@ import { ToolContext } from "../Tools/ToolProvider"
 import { MaterialContext } from "../Materials/MaterialProvider"
 import { Form, FormLabel, Button, Jumbotron, Modal } from "react-bootstrap";
 import { Multiselect } from 'multiselect-react-dropdown'
-import Card from 'react-bootstrap/Card'
-import Container from 'react-bootstrap/Container'
+
 // import "./Project.css"
 
 export const ProjectEdit = () => {

--- a/src/components/ProjectsBoard/Project.js
+++ b/src/components/ProjectsBoard/Project.js
@@ -6,12 +6,14 @@ import Button from 'react-bootstrap/Button'
 import Card from 'react-bootstrap/Card'
 import Container from 'react-bootstrap/Container'
 import { useHistory } from "react-router-dom"
+import { ProjectToolContext } from "../Tools/ToolProjectProvider.js"
 // import "./Project.css"
 
 export const ProjectCard = ({ project }) => {
     
     const { deleteProject, editProject, getProjects } = useContext(ProjectContext)
     const { getProjectsMaterials, projectsMaterials } = useContext(ProjectMaterialContext)
+    const { getProjectsTools, projectsTools } = useContext(ProjectToolContext)
     const { materials, getMaterials } = useContext(MaterialContext)
 
     //gives an object with methods on it. then goes back "through history" to new url
@@ -34,33 +36,31 @@ export const ProjectCard = ({ project }) => {
     useEffect(() => {
         getProjects()
         .then(getProjectsMaterials)
+        .then(getProjectsTools)
         // .then(getMaterials())
     }, [])
     
-        // map through projmaterials to find material(single object) CONTINUE 
-    // let matchingProjMat = projectMaterial.map(material => {
-    //     materials.find(materialName => {
-    //         return materialName.id === material.id
-    //     })
-    // }
-
-    // )
-
-    // let matchingProjectMaterialId = projectsMaterials.
-
     return (
         <Card className="ProjectCard">
                 {console.log("pm", materials)}
             <Card.Title className="projectName">{project.name}</Card.Title>
             <div className="projectDescription">Description: {project.description}</div>
             <div className="projectcategory">Category: {project.category?.name}</div>
-            {/* <div className="projectTools">Tools Needed: </div> */}
+            <div className="projectTools">Tools Needed: 
+            { 
+                    projectsTools.map(pt => {
+                        if (pt.projectId === project.id) 
+                        return <div> {pt.tool.name} </div>}
+                        )
+            }
+            </div>
             <div className="projectsMaterials">Materials Needed: 
             { 
-                    projectsMaterials.map(materialProp => {
-                            return <div> {materialProp.material.name} </div>
-                    })
-                }
+                    projectsMaterials.map(pm => {
+                        if (pm.projectId === project.id) 
+                        return <div> {pm.material.name} </div>}
+                        )
+            }
             </div>
             <div className="projectCreationDate">Date Started: {project.dateCreated}</div>
             <div className="projectCompletionDate">Complete by: {project.dateDue}</div>

--- a/src/components/ProjectsBoard/Project.js
+++ b/src/components/ProjectsBoard/Project.js
@@ -14,7 +14,7 @@ export const ProjectCard = ({ project }) => {
     const { deleteProject, editProject, getProjects } = useContext(ProjectContext)
     const { getProjectsMaterials, projectsMaterials } = useContext(ProjectMaterialContext)
     const { getProjectsTools, projectsTools } = useContext(ProjectToolContext)
-    const { materials, getMaterials } = useContext(MaterialContext)
+    // const { materials, getMaterials } = useContext(MaterialContext)
 
     //gives an object with methods on it. then goes back "through history" to new url
     const history = useHistory()
@@ -42,7 +42,6 @@ export const ProjectCard = ({ project }) => {
     
     return (
         <Card className="ProjectCard">
-                {console.log("pm", materials)}
             <Card.Title className="projectName">{project.name}</Card.Title>
             <div className="projectDescription">Description: {project.description}</div>
             <div className="projectcategory">Category: {project.category?.name}</div>

--- a/src/components/ProjectsBoard/ProjectBoard.js
+++ b/src/components/ProjectsBoard/ProjectBoard.js
@@ -1,39 +1,59 @@
-import { useContext, useEffect } from "react"
+import { useContext, useEffect, useState } from "react"
 import { ProjectContext } from "./ProjectProvider.js"
 import { ProjectCard } from "./Project.js"
 import { userStorageKey } from "../auth/authSettings.js"
 import Button from 'react-bootstrap/Button';
-import { CardDeck, Jumbotron } from "react-bootstrap";
+import { CardDeck, Form, Jumbotron } from "react-bootstrap";
 import "./ProjectBoard.css"
 
 export const ProjectBoard = () => {
-    const { projects, getProjects } = useContext(ProjectContext)
- 
+    const { projects, getProjects, getCategories, categories } = useContext(ProjectContext)
+    // const [filteredProjects, setFilteredProjects] = useState([])
+
+
     let currentUser = parseInt(sessionStorage.getItem(userStorageKey))
-    
+
+
     useEffect(() => {
         getProjects()
+            .then(getCategories())
     }, [])
-    
+
     // filters through projects to only return those with matching userId
     let userProjects = projects.filter(project => currentUser === project.userId)
+
+    const handleFilterProjects = (event) => {
+        let selectedVal = event.target.value
+        if (event.target.id !== "0") {
+            projects.filter(project => {
+                return project.classId === parseInt(selectedVal)
+            })
+            {console.log(selectedVal)}
+        }
+    }  
+
 
     return (
         <>
             <Jumbotron className="projectsTitle"> <h3>projects</h3> </Jumbotron>
             <div className="sortButtons">
-                <p>Sort projects by: </p>
-            <Button>Category</Button>
-            <Button>Date Created(date due?)</Button>
+                <p>Sort projects by category: </p>
+                <Form.Control as="select" custom id="categoryId" onChange={handleFilterProjects}>
+                    <option value="0">Select a Category</option>
+                    {
+                        categories.map(selectCategory => <option value={selectCategory.id}>{selectCategory.name}</option>)
+                    }
+                </Form.Control>
+                {/* <Button>Date Created(date due?)</Button> */}
             </div>
-        <CardDeck>
-            {
-                userProjects.map(project => {
-                    // console.log("material", materials)
-                    return <ProjectCard key={project.id}
-                                        project={project} /> 
-                })
-                                }
+            <CardDeck>
+                {
+                    userProjects.map(project => {
+                        // console.log("material", materials)
+                        return <ProjectCard key={project.id}
+                            project={project} />
+                    })
+                }
             </CardDeck>
         </>
     )

--- a/src/components/Tools/ToolProjectProvider.js
+++ b/src/components/Tools/ToolProjectProvider.js
@@ -1,42 +1,43 @@
-// import { useState, createContext } from "react"
+import { useState, createContext } from "react"
 
-// export const ToolMaterialContext = createContext()
+//context provides a way to pass data through components tree w/o having to pass props DOWN manually at every level
+export const ProjectToolContext = createContext()
 
-// export const {ToolMaterialProvider} = (props) => {
+export const ProjectToolProvider = (props) => {
 
-//     //useState stores data about component
-//     const [toolsMaterials, setToolsMaterials] = useState([])
+    //useState stores data about component
+    const [projectsTools, setProjectsTools] = useState([])
 
-//     const getProjectsTools = () => {
-//         return fetch("http://localhost:8088/projectsTools")
-//         .then(response => response.json())
-//         .then(setMaterials)
-//     }
+    const getProjectsTools = () => {
+        return fetch("http://localhost:8088/projectsTools?_expand=tool&_expand=project")
+        .then(response => response.json())
+        .then(setProjectsTools)
+    }
 
-//     // const getProjectlById = (id) => {
-//     //     return fetch(`http://localhost:8088/projects/${id}`)
-//     //         .then(res => res.json())
-//     // }
+    const getProjectToolById = (id) => {
+        return fetch(`http://localhost:8088/projects/${id}`)
+            .then(res => res.json())
+    }
 
-//     //addprojectmaterial. to add all of the materials to project materials 
+    //addprojectmaterial. to add all of the materials to project materials 
 
-//     const addprojectMaterial = projectMaterialObj => {
-//         return fetch("http://localhost:8088/projectsMaterials",{
-//         method: "POST",
-//         headers: {
-//             "Content-Type": "application/json"
-//         },
-//         body: JSON.stringify(projectMaterialObj)
-//         })
-//             .then(getProjectsMaterials)
-//     }
+    const addProjectTool = projectToolObj => {
+        return fetch("http://localhost:8088/projectsTools",{
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(projectToolObj)
+        })
+            .then(getProjectsTools)
+    }
 
-//     //DONT FORGET TO COMMENT OUT WHAT THIS IS DOING????
-//     return (
-//         <ProjectMaterialContext.Provider value={{
-//             projectsMaterials, getProjectsMaterials, addProjectsMaterial
-//         }}>
-//             {props.children}
-//         </ProjectMaterialContext.Provider>
-//     )
-// }
+    //DONT FORGET TO COMMENT OUT WHAT THIS IS DOING????
+    return (
+        <ProjectToolContext.Provider value={{
+            projectsTools, getProjectsTools, addProjectTool, getProjectToolById
+        }}>
+            {props.children}
+        </ProjectToolContext.Provider>
+    )
+}

--- a/src/components/Tools/ToolProvider.js
+++ b/src/components/Tools/ToolProvider.js
@@ -1,5 +1,6 @@
 import { useState, createContext } from "react"
 
+//asigns a way to pass data w/o having to pass props manually by using createContext
 export const ToolContext = createContext()
 
 export const ToolProvider = (props) => {


### PR DESCRIPTION
# Description
Tools and materials can now be added on the add project page. the save button on each modal also closes the modal. once saved/closed. materials and tools appear in dropdown w/o needing to refresh page 
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# Testing Instructions
```
git fetch --all
git checkout <branch-name>
```

# Checklist:
- [ ] (I have commented my code. Especially w/ hard to understand code)
- [X] (Changes I have made generate no new warnings or errors)
